### PR TITLE
Prod is now the default of CLI

### DIFF
--- a/clients/rust/src/constants.rs
+++ b/clients/rust/src/constants.rs
@@ -3,9 +3,9 @@ use url::Url;
 
 pub static BASE_URL_ENV: &str = "CRONBACK_BASE_URL";
 pub static DEFAULT_BASE_URL: Lazy<Url> = Lazy::new(|| {
-    // Default in build is (jungle), production URL is only set if the build
+    // Default in build is (prod), jungle URL is only set if the build
     // explicitly sets CRONBACK_DEFAULT_BASE_URL at compile time.
     let url_str = std::option_env!("CRONBACK_DEFAULT_BASE_URL")
-        .unwrap_or("https://api.jungle.cronback.me");
+        .unwrap_or("https://api.cronback.me");
     Url::parse(url_str).expect("DEFAULT_BASE_URL")
 });


### PR DESCRIPTION
Prod is now the default of CLI. This is necessary to publish `cronback-cli` to the registry.
