### PR TITLE
[2/n] API to delete triggers for a project in scheduler

### DIFF
--- a/cronback-proto/scheduler.proto
+++ b/cronback-proto/scheduler.proto
@@ -25,6 +25,10 @@ service Scheduler {
   rpc DeleteTrigger (DeleteTriggerRequest) returns (DeleteTriggerResponse);
   /// Find trigger id by name
   rpc GetTriggerId (GetTriggerIdRequest) returns (GetTriggerIdResponse);
+  /// Find trigger id by name
+
+  /// Immediately deletes all triggers for a project
+  rpc DeleteProjectTriggers (DeleteProjectTriggersRequest) returns (DeleteProjectTriggersResponse);
 }
 
 enum RunMode {
@@ -124,4 +128,11 @@ message GetTriggerIdRequest {
 
 message GetTriggerIdResponse {
   common.TriggerId id = 1;
+}
+
+// DELETE PROJECT TRIGGERS -- Project is set in request context.
+message DeleteProjectTriggersRequest {
+}
+
+message DeleteProjectTriggersResponse {
 }

--- a/services/cronback-scheduler-srv/src/handler.rs
+++ b/services/cronback-scheduler-srv/src/handler.rs
@@ -6,6 +6,8 @@ use proto::scheduler_proto::scheduler_server::Scheduler;
 use proto::scheduler_proto::{
     CancelTriggerRequest,
     CancelTriggerResponse,
+    DeleteProjectTriggersRequest,
+    DeleteProjectTriggersResponse,
     DeleteTriggerRequest,
     DeleteTriggerResponse,
     GetTriggerIdRequest,
@@ -154,6 +156,15 @@ impl Scheduler for SchedulerAPIHandler {
                 .collect(),
             pagination: Some(paginated_result.pagination),
         }))
+    }
+
+    async fn delete_project_triggers(
+        &self,
+        request: Request<DeleteProjectTriggersRequest>,
+    ) -> Result<Response<DeleteProjectTriggersResponse>, Status> {
+        let ctx = request.context()?;
+        self.scheduler.delete_project_triggers(ctx).await?;
+        Ok(Response::new(DeleteProjectTriggersResponse {}))
     }
 
     async fn get_trigger_id(

--- a/services/cronback-scheduler-srv/src/trigger_store.rs
+++ b/services/cronback-scheduler-srv/src/trigger_store.rs
@@ -63,6 +63,11 @@ pub trait TriggerStore {
         pagination: PaginationIn,
         statuses: Option<Vec<Status>>,
     ) -> Result<PaginatedResponse<Trigger>, TriggerStoreError>;
+
+    async fn delete_triggers_by_project(
+        &self,
+        project: &ProjectId,
+    ) -> Result<(), TriggerStoreError>;
 }
 
 pub struct SqlTriggerStore {
@@ -107,6 +112,17 @@ impl TriggerStore for SqlTriggerStore {
         trigger_id: &TriggerId,
     ) -> Result<(), TriggerStoreError> {
         Triggers::delete_by_id((trigger_id.clone(), project.clone()))
+            .exec(&self.db.orm)
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_triggers_by_project(
+        &self,
+        project: &ProjectId,
+    ) -> Result<(), TriggerStoreError> {
+        Triggers::delete_many()
+            .filter(triggers::Column::ProjectId.eq(project.clone()))
             .exec(&self.db.orm)
             .await?;
         Ok(())

--- a/services/cronback-scheduler-srv/tests/scheduler_test.rs
+++ b/services/cronback-scheduler-srv/tests/scheduler_test.rs
@@ -2,8 +2,11 @@ use std::sync::Arc;
 
 use cronback_scheduler_srv::test_helpers;
 use dto::traits::ProstOptionExt;
+use lib::clients::scheduler_client::ScopedSchedulerClient;
 use lib::config::{ConfigLoader, Role};
+use lib::grpc_client_provider::test_helpers::TestGrpcClientProvider;
 use lib::grpc_client_provider::GrpcClientFactory;
+use lib::prelude::*;
 use lib::service::ServiceContext;
 use lib::shutdown::Shutdown;
 use lib::types::{ProjectId, RequestId};
@@ -15,7 +18,15 @@ use proto::common::{
     UpsertEffect,
     Webhook,
 };
-use proto::scheduler_proto::{GetTriggerRequest, UpsertTriggerRequest};
+use proto::scheduler_proto::{
+    DeleteProjectTriggersRequest,
+    GetTriggerRequest,
+    GetTriggerResponse,
+    ListTriggersRequest,
+    ListTriggersResponse,
+    UpsertTriggerRequest,
+    UpsertTriggerResponse,
+};
 use proto::trigger_proto::{
     schedule,
     Recurring,
@@ -26,6 +37,98 @@ use proto::trigger_proto::{
 use tonic::Request;
 use tracing::info;
 use tracing_test::traced_test;
+
+fn make_trigger(
+    name: impl Into<String>,
+    scheduled: bool,
+    description: impl Into<String>,
+) -> Trigger {
+    let schedule = if scheduled {
+        Some(Schedule {
+            schedule: Some(schedule::Schedule::Recurring(Recurring {
+                cron: "0 * * * * *".to_owned(),
+                timezone: "Europe/London".into(),
+                limit: Some(4),
+                ..Default::default()
+            })),
+        })
+    } else {
+        None
+    };
+
+    Trigger {
+        payload: Some(Payload {
+            body: "Hello World".into(),
+            ..Default::default()
+        }),
+        name: name.into(),
+        description: Some(description.into()),
+        action: Some(Action {
+            action: Some(action::Action::Webhook(Webhook {
+                url: "http://localhost:3000".to_owned(),
+                http_method: HttpMethod::Get.into(),
+                timeout_s: 30.0,
+                retry: None,
+            })),
+        }),
+        status: Default::default(),
+        schedule,
+        ..Default::default()
+    }
+}
+
+async fn install_trigger(
+    client_provider: &TestGrpcClientProvider<ScopedSchedulerClient>,
+    project: &ValidShardedId<ProjectId>,
+    trigger: Trigger,
+) -> UpsertTriggerResponse {
+    let upsert = UpsertTriggerRequest {
+        precondition: None,
+        trigger_name: None,
+        trigger: Some(trigger),
+    };
+    client_provider
+        .get_client(&RequestId::new(), project)
+        .await
+        .unwrap()
+        .upsert_trigger(Request::new(upsert))
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+async fn list_triggers(
+    client_provider: &TestGrpcClientProvider<ScopedSchedulerClient>,
+    project: &ValidShardedId<ProjectId>,
+) -> ListTriggersResponse {
+    let list = ListTriggersRequest::default();
+    client_provider
+        .get_client(&RequestId::new(), project)
+        .await
+        .unwrap()
+        .list_triggers(Request::new(list))
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+async fn get_trigger(
+    client_provider: &TestGrpcClientProvider<ScopedSchedulerClient>,
+    project: &ValidShardedId<ProjectId>,
+    trigger_name: &str,
+) -> Option<GetTriggerResponse> {
+    let get = GetTriggerRequest {
+        name: trigger_name.to_owned(),
+    };
+    client_provider
+        .get_client(&RequestId::new(), project)
+        .await
+        .unwrap()
+        .get_trigger(Request::new(get))
+        .await
+        .ok()
+        .map(|r| r.into_inner())
+}
 
 #[traced_test]
 #[tokio::test]
@@ -261,4 +364,134 @@ async fn install_trigger_uniqueness_test() {
     // updated at is set.
     assert_ne!(None, updated_trigger.updated_at);
     assert_eq!(TriggerStatus::OnDemand, updated_trigger.status());
+}
+
+#[traced_test]
+#[tokio::test]
+async fn delete_project_triggers_test() {
+    let shutdown = Shutdown::default();
+    let config_loader = Arc::new(ConfigLoader::from_path(&None));
+    let context = ServiceContext::new(
+        format!("{:?}", Role::Scheduler),
+        config_loader,
+        shutdown,
+    );
+
+    let project1 = ProjectId::generate();
+    let project2 = ProjectId::generate();
+
+    info!("Initialising test server...");
+    let (_serve_future, client_provider) =
+        test_helpers::test_server_and_client(context).await;
+
+    let mut project1_triggers = vec![];
+    let mut project2_triggers = vec![];
+
+    // ** Project 1**
+    // 3 scheduled triggers
+    for i in 0..3 {
+        let trigger_name = format!("project-trigger-{}", i);
+        let install_resp = install_trigger(
+            &client_provider,
+            &project1,
+            make_trigger(
+                trigger_name,
+                /* scheduled = */ true,
+                /* description = */ "project1",
+            ),
+        )
+        .await;
+        assert_eq!(UpsertEffect::Created, install_resp.effect());
+        project1_triggers.push(install_resp.trigger.unwrap().name);
+    }
+    // 2 on-demand triggers
+    for i in 0..2 {
+        let trigger_name = format!("project-on-demand-trigger-{}", i);
+        let install_resp = install_trigger(
+            &client_provider,
+            &project1,
+            make_trigger(
+                trigger_name,
+                /* scheduled = */ false,
+                /* description = */ "project1",
+            ),
+        )
+        .await;
+        assert_eq!(UpsertEffect::Created, install_resp.effect());
+        project1_triggers.push(install_resp.trigger.unwrap().name);
+    }
+
+    // validate that all triggers are installed
+    let list_resp = list_triggers(&client_provider, &project1).await;
+    assert_eq!(5, list_resp.triggers.len());
+
+    // ** Project 2**
+    // Adding 3 scheduled triggers to project2 to validate they are not deleted.
+    for i in 0..3 {
+        let trigger_name = format!("project-trigger-{}", i);
+        let install_resp = install_trigger(
+            &client_provider,
+            &project2,
+            make_trigger(
+                &trigger_name,
+                /* scheduled = */ true,
+                /* description = */ "project2",
+            ),
+        )
+        .await;
+        assert_eq!(UpsertEffect::Created, install_resp.effect());
+        project2_triggers.push(install_resp.trigger.unwrap().name);
+    }
+
+    // Project1 triggers exist and correct
+    for name in &project1_triggers {
+        info!(name = name, "Getting trigger");
+        let get_resp = get_trigger(&client_provider, &project1, &name).await;
+        assert!(get_resp.is_some());
+        let get_resp = get_resp.unwrap();
+        assert_eq!("project1", get_resp.trigger.unwrap().description());
+    }
+
+    // Project2 triggers exist and correct
+    // BUG: https://github.com/devtari-io/cronback/issues/6
+    // for name in &project2_triggers {
+    //     info!("Getting trigger {}", name);
+    //     let get_resp = get_trigger(&client_provider, &project2, &name).await;
+    //     assert!(get_resp.is_some());
+    //     let get_resp = get_resp.unwrap();
+    //     assert_eq!("project2", get_resp.trigger.unwrap().description());
+    // }
+
+    // Now, delete all triggers for this project
+    let list = DeleteProjectTriggersRequest::default();
+    client_provider
+        .get_client(&RequestId::new(), &project1)
+        .await
+        .unwrap()
+        .delete_project_triggers(Request::new(list))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Project 1 triggers should be deleted
+    let list_resp = list_triggers(&client_provider, &project1).await;
+    assert_eq!(0, list_resp.triggers.len());
+
+    // even getting individual scheduled triggers should return nothing.
+    for name in &project1_triggers {
+        info!(name = name, "Getting trigger");
+        let get_resp = get_trigger(&client_provider, &project1, &name).await;
+        assert_eq!(None, get_resp);
+    }
+
+    // Project2 are intact
+    let list_resp = list_triggers(&client_provider, &project2).await;
+    assert_eq!(3, list_resp.triggers.len());
+    for name in &project2_triggers {
+        info!(name = name, "Getting trigger");
+        let get_resp = get_trigger(&client_provider, &project2, &name).await;
+        assert!(get_resp.is_some());
+        let get_resp = get_resp.unwrap();
+        assert_eq!("project2", get_resp.trigger.unwrap().description());
+    }
 }


### PR DESCRIPTION
[2/n] API to delete triggers for a project in scheduler

Summary:
Adds a new gGRPC API to scheduler to delete all triggers for a given project.
It doesn't remove runs or attempts, only triggers.


Part of the test is commented until #6 is fixed (will be next in stack)

Test Plan: Integration test

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/devtari-io/cronback/pull/8).
* #9
* __->__ #8
* #7