### PR TITLE
[Events] Add project notification settings

### DIFF
--- a/cronback-api-model/src/admin/mod.rs
+++ b/cronback-api-model/src/admin/mod.rs
@@ -1,5 +1,7 @@
 mod api_keys;
+mod notifications;
 mod projects;
 
 pub use api_keys::*;
+pub use notifications::*;
 pub use projects::*;

--- a/cronback-api-model/src/admin/notifications.rs
+++ b/cronback-api-model/src/admin/notifications.rs
@@ -1,0 +1,240 @@
+use std::collections::HashMap;
+
+#[cfg(feature = "dto")]
+use dto::{FromProto, IntoProto};
+use monostate::MustBe;
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "validation")]
+use validator::Validate;
+
+#[cfg(feature = "validation")]
+use crate::validation_util::validation_error;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "dto",
+    derive(IntoProto, FromProto),
+    proto(target = "proto::notifications::ProjectNotificationSettings")
+)]
+#[cfg_attr(
+    feature = "validation",
+    derive(Validate),
+    validate(schema(
+        function = "validate_settings",
+        skip_on_field_errors = false
+    ))
+)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationSettings {
+    #[cfg_attr(feature = "validation", validate)]
+    pub default_subscriptions: Vec<NotificationSubscription>,
+    // The key of the hashmap is the channel name
+    #[cfg_attr(feature = "validation", validate)]
+    pub channels: HashMap<String, NotificationChannel>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "dto",
+    derive(IntoProto, FromProto),
+    proto(target = "proto::notifications::NotificationSubscription")
+)]
+#[cfg_attr(feature = "validation", derive(Validate))]
+#[serde(deny_unknown_fields)]
+pub struct NotificationSubscription {
+    #[cfg_attr(feature = "validation", validate(length(max = 20)))]
+    pub channel_names: Vec<String>,
+    #[cfg_attr(feature = "dto", proto(required))]
+    #[cfg_attr(feature = "validation", validate)]
+    pub event: NotificationEvent,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "dto",
+    derive(IntoProto, FromProto),
+    proto(
+        target = "proto::notifications::NotificationChannel",
+        oneof = "channel"
+    )
+)]
+#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
+pub enum NotificationChannel {
+    Email(EmailNotification),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "dto",
+    derive(IntoProto, FromProto),
+    proto(target = "proto::notifications::NotificationEvent", oneof = "event")
+)]
+#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
+pub enum NotificationEvent {
+    OnRunFailure(OnRunFailure),
+}
+
+// Channel configs
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "dto",
+    derive(IntoProto, FromProto),
+    proto(target = "proto::notifications::Email")
+)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "validation", derive(Validate))]
+pub struct EmailNotification {
+    #[serde(rename = "type")]
+    _kind: MustBe!("email"),
+    #[cfg_attr(feature = "validation", validate(email))]
+    pub address: String,
+    pub verified: bool,
+}
+
+// Subscription configs
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "dto",
+    derive(IntoProto, FromProto),
+    proto(target = "proto::notifications::OnRunFailure")
+)]
+#[cfg_attr(feature = "validation", derive(Validate))]
+#[serde(deny_unknown_fields)]
+pub struct OnRunFailure {
+    #[serde(rename = "type")]
+    _kind: MustBe!("on_run_failure"),
+}
+
+#[cfg(feature = "validation")]
+impl Validate for NotificationEvent {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            | NotificationEvent::OnRunFailure(o) => o.validate(),
+        }
+    }
+}
+
+#[cfg(feature = "validation")]
+impl Validate for NotificationChannel {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        match self {
+            | NotificationChannel::Email(e) => e.validate(),
+        }
+    }
+}
+
+#[cfg(feature = "validation")]
+fn validate_settings(
+    settings: &NotificationSettings,
+) -> Result<(), validator::ValidationError> {
+    // Validate that any channel referenced in a subscription actually exists.
+
+    for sub in &settings.default_subscriptions {
+        for channel in &sub.channel_names {
+            if !settings.channels.contains_key(channel) {
+                return Err(validation_error(
+                    "invalid_channel_name",
+                    format!(
+                        "Channel name '{}' is not configured in channel list",
+                        channel
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn test_valid_settings() -> anyhow::Result<()> {
+        let email = EmailNotification {
+            _kind: Default::default(),
+            address: "test@gmail.com".to_string(),
+            verified: true,
+        };
+        let mut channels = HashMap::new();
+        channels.insert("email".to_string(), NotificationChannel::Email(email));
+        let setting = NotificationSettings {
+            channels,
+            default_subscriptions: vec![NotificationSubscription {
+                channel_names: vec!["email".to_string()],
+                event: NotificationEvent::OnRunFailure(OnRunFailure {
+                    _kind: Default::default(),
+                }),
+            }],
+        };
+
+        setting.validate()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_email() -> anyhow::Result<()> {
+        let email = EmailNotification {
+            _kind: Default::default(),
+            address: "wrong_email".to_string(),
+            verified: false,
+        };
+        let mut channels = HashMap::new();
+        channels.insert("email".to_string(), NotificationChannel::Email(email));
+        let setting = NotificationSettings {
+            channels,
+            default_subscriptions: vec![],
+        };
+
+        let validated = setting.validate();
+
+        assert!(validated.is_err());
+        assert_eq!(
+            validated.unwrap_err().to_string(),
+            "channels[0].address: Validation error: email [{\"value\": \
+             String(\"wrong_email\")}]"
+                .to_string()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_channel() {
+        let email = EmailNotification {
+            _kind: Default::default(),
+            address: "test@gmail.com".to_string(),
+            verified: false,
+        };
+        let mut channels = HashMap::new();
+        channels.insert("email".to_string(), NotificationChannel::Email(email));
+        let setting = NotificationSettings {
+            channels,
+            default_subscriptions: vec![NotificationSubscription {
+                channel_names: vec![
+                    "email".to_string(),
+                    "wrong_channel".to_string(),
+                ],
+                event: NotificationEvent::OnRunFailure(OnRunFailure {
+                    _kind: Default::default(),
+                }),
+            }],
+        };
+
+        let validated = setting.validate();
+
+        assert!(validated.is_err());
+        assert_eq!(
+            validated.unwrap_err().to_string(),
+            "__all__: Channel name 'wrong_channel' is not configured in \
+             channel list"
+                .to_string()
+        );
+    }
+}

--- a/cronback-dto-core/src/utils.rs
+++ b/cronback-dto-core/src/utils.rs
@@ -29,6 +29,11 @@ pub(crate) fn vec_segment(path: &syn::Path) -> Option<&syn::PathSegment> {
     extract_generic_type_segment(path, VECTOR)
 }
 
+pub(crate) fn map_segment(path: &syn::Path) -> Option<&syn::PathSegment> {
+    static MAP: &[&str] = &["HashMap|", "std|collections|HashMap|"];
+    extract_generic_type_segment(path, MAP)
+}
+
 fn extract_type_path(ty: &syn::Type) -> Option<&syn::Path> {
     match *ty {
         | syn::Type::Path(ref typepath) if typepath.qself.is_none() => {

--- a/cronback-proto/build.rs
+++ b/cronback-proto/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "./runs.proto",
                 "./scheduler_svc.proto",
                 "./triggers.proto",
+                "./notifications.proto",
             ],
             &["../proto"],
         )?;
@@ -36,6 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ".events",
             ".projects",
             ".triggers",
+            ".notifications",
         ])?;
 
     Ok(())

--- a/cronback-proto/lib.rs
+++ b/cronback-proto/lib.rs
@@ -80,5 +80,9 @@ pub mod projects {
     include!(concat!(env!("OUT_DIR"), "/projects.serde.rs"));
 }
 
+pub mod notifications {
+    tonic::include_proto!("notifications");
+}
+
 pub const FILE_DESCRIPTOR_SET: &[u8] =
     tonic::include_file_descriptor_set!("file_descriptor");

--- a/cronback-proto/metadata_svc.proto
+++ b/cronback-proto/metadata_svc.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "common.proto";
 import "projects.proto";
+import "notifications.proto";
 
 package metadata_svc;
 
@@ -10,6 +11,8 @@ service MetadataSvc {
   rpc GetProjectStatus(GetProjectStatusRequest) returns (GetProjectStatusResponse);
   rpc SetProjectStatus(SetProjectStatusRequest) returns (SetProjectStatusResponse);
   rpc ProjectExists(ProjectExistsRequest) returns (ProjectExistsResponse);
+  rpc GetNotificationSettings(GetNotificationSettingsRequest) returns (GetNotificationSettingsResponse);
+  rpc SetNotificationSettings(SetNotificationSettingsRequest) returns (SetNotificationSettingsResponse);
 }
 
 message CreateProjectRequest {
@@ -43,5 +46,23 @@ message ProjectExistsRequest {
 
 message ProjectExistsResponse {
   bool exists = 1;
+}
+
+message GetNotificationSettingsRequest {
+  common.ProjectId id = 1;
+}
+
+message GetNotificationSettingsResponse {
+  notifications.ProjectNotificationSettings settings = 1;
+}
+
+
+message SetNotificationSettingsRequest {
+  common.ProjectId id = 1;
+  notifications.ProjectNotificationSettings settings = 2;
+}
+
+message SetNotificationSettingsResponse {
+  notifications.ProjectNotificationSettings old_settings = 1;
 }
 

--- a/cronback-proto/notifications.proto
+++ b/cronback-proto/notifications.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package notifications;
+
+// This struct represents the notification settings of a single project.
+// Every project has different kind of notification channels (e.g. email, slack, etc).
+// A project then subscribes to certain events, and specify which channels should the
+// notification be sent on if the event fires.
+message ProjectNotificationSettings {
+    repeated NotificationSubscription default_subscriptions = 1;
+
+    // The list of configured channels. The map key is the channel name and the value
+    // is the channel configuration.
+    map<string, NotificationChannel> channels = 2;
+}
+
+message NotificationSubscription {
+    // The list of channel names to send notifications to. Items in this list must
+    // refer to channels configured in this project.
+    repeated string channel_names = 1;
+
+    // The event type that this subscription will fire on.
+    NotificationEvent event = 2;
+}
+
+message NotificationChannel {
+    oneof channel {
+        Email email = 1;
+    }
+}
+
+message NotificationEvent {
+    oneof event {
+        OnRunFailure on_run_failure = 1;
+    }
+}
+
+//////////////// Channels
+
+// Sends an email to the address specified if and only if its a verified address.
+message Email {
+    string address = 1;
+    bool verified = 2;
+}
+
+
+//////////////// Events
+
+// Trigger the subscription if a run in this project fails.
+message OnRunFailure {
+}

--- a/cronback-services/src/api/handlers/admin/mod.rs
+++ b/cronback-services/src/api/handlers/admin/mod.rs
@@ -25,6 +25,14 @@ pub(crate) fn routes(shared_state: Arc<AppState>) -> Router {
                 .route("/", axum::routing::post(projects::create))
                 .route("/:id/disable", axum::routing::post(projects::disable))
                 .route("/:id/enable", axum::routing::post(projects::enable))
+                .route(
+                    "/:id/notification_settings",
+                    axum::routing::post(projects::set_notification_settings),
+                )
+                .route(
+                    "/:id/notification_settings",
+                    axum::routing::get(projects::get_notification_settings),
+                )
                 .with_state(Arc::clone(&shared_state))
                 .route_layer(middleware::from_fn(ensure_admin)),
         )

--- a/cronback-services/src/api/handlers/admin/projects.rs
+++ b/cronback-services/src/api/handlers/admin/projects.rs
@@ -3,13 +3,22 @@ use std::sync::Arc;
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
-use cronback_api_model::admin::CreateProjectResponse as CreateProjectHttpResponse;
+use cronback_api_model::admin::{
+    CreateProjectResponse as CreateProjectHttpResponse,
+    NotificationSettings,
+};
 use hyper::StatusCode;
 use lib::prelude::*;
-use proto::metadata_svc::{CreateProjectRequest, SetProjectStatusRequest};
+use proto::metadata_svc::{
+    CreateProjectRequest,
+    GetNotificationSettingsRequest,
+    SetNotificationSettingsRequest,
+    SetProjectStatusRequest,
+};
 use proto::projects::ProjectStatus;
 
 use crate::api::errors::ApiError;
+use crate::api::extractors::ValidatedJson;
 use crate::api::AppState;
 
 #[tracing::instrument(skip(state))]
@@ -22,12 +31,12 @@ pub(crate) async fn create(
         .metadata_svc_clients
         .get_client(&request_id, &id)
         .await?;
-    let (_, resp, _) = metadata
+    let resp = metadata
         .create_project(CreateProjectRequest {
             id: Some(id.clone().into()),
         })
         .await?
-        .into_parts();
+        .into_inner();
     let response = CreateProjectHttpResponse {
         id: resp.id.unwrap().value,
     };
@@ -85,4 +94,54 @@ pub(crate) async fn disable(
         ProjectStatus::Disabled,
     )
     .await
+}
+
+#[tracing::instrument(skip(state))]
+pub(crate) async fn get_notification_settings(
+    state: State<Arc<AppState>>,
+    Path(project_id_str): Path<String>,
+    Extension(request_id): Extension<RequestId>,
+) -> Result<impl IntoResponse, ApiError> {
+    let project_id = ProjectId::from(project_id_str.clone())
+        .validated()
+        .map_err(move |_| ApiError::NotFound(project_id_str))?;
+
+    let mut metadata = state
+        .metadata_svc_clients
+        .get_client(&request_id, &project_id)
+        .await?;
+    let resp = metadata
+        .get_notification_settings(GetNotificationSettingsRequest {
+            id: Some(project_id.into()),
+        })
+        .await?
+        .into_inner();
+
+    let settings: NotificationSettings = resp.settings.unwrap().into();
+
+    Ok(Json(settings))
+}
+
+#[tracing::instrument(skip(state))]
+pub(crate) async fn set_notification_settings(
+    state: State<Arc<AppState>>,
+    Path(project_id_str): Path<String>,
+    Extension(request_id): Extension<RequestId>,
+    ValidatedJson(settings): ValidatedJson<NotificationSettings>,
+) -> Result<impl IntoResponse, ApiError> {
+    let project_id = ProjectId::from(project_id_str.clone())
+        .validated()
+        .map_err(move |_| ApiError::NotFound(project_id_str))?;
+
+    let mut metadata = state
+        .metadata_svc_clients
+        .get_client(&request_id, &project_id)
+        .await?;
+    metadata
+        .set_notification_settings(SetNotificationSettingsRequest {
+            id: Some(project_id.into()),
+            settings: Some(settings.into()),
+        })
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/cronback-services/src/metadata/db_model/mod.rs
+++ b/cronback-services/src/metadata/db_model/mod.rs
@@ -1,3 +1,4 @@
+pub mod notifications;
 pub mod projects;
 
 pub use projects::{Entity as Projects, Model as Project, ProjectStatus};

--- a/cronback-services/src/metadata/db_model/notifications.rs
+++ b/cronback-services/src/metadata/db_model/notifications.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use dto::{FromProto, IntoProto};
+use sea_orm::FromJsonQueryResult;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    FromJsonQueryResult,
+    FromProto,
+    IntoProto,
+)]
+#[proto(target = "proto::notifications::ProjectNotificationSettings")]
+pub struct NotificationSettings {
+    pub default_subscriptions: Vec<NotificationSubscription>,
+    pub channels: HashMap<String, NotificationChannel>,
+}
+
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromProto, IntoProto,
+)]
+#[proto(target = "proto::notifications::NotificationSubscription")]
+pub struct NotificationSubscription {
+    pub channel_names: Vec<String>,
+    #[proto(required)]
+    pub event: NotificationEvent,
+}
+
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromProto, IntoProto,
+)]
+#[proto(
+    target = "proto::notifications::NotificationChannel",
+    oneof = "channel"
+)]
+pub enum NotificationChannel {
+    Email(EmailNotification),
+}
+
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromProto, IntoProto,
+)]
+#[proto(target = "proto::notifications::NotificationEvent", oneof = "event")]
+pub enum NotificationEvent {
+    OnRunFailure(OnRunFailure),
+}
+
+// Channel configs
+
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromProto, IntoProto,
+)]
+#[proto(target = "proto::notifications::Email")]
+pub struct EmailNotification {
+    pub address: String,
+    pub verified: bool,
+}
+
+// Subscription configs
+
+#[derive(
+    Clone, Debug, Serialize, Deserialize, PartialEq, Eq, FromProto, IntoProto,
+)]
+#[proto(target = "proto::notifications::OnRunFailure")]
+pub struct OnRunFailure {}

--- a/cronback-services/src/metadata/db_model/projects.rs
+++ b/cronback-services/src/metadata/db_model/projects.rs
@@ -5,6 +5,8 @@ use dto::{FromProto, IntoProto};
 use lib::prelude::*;
 use sea_orm::entity::prelude::*;
 
+use super::notifications::NotificationSettings;
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "projects")]
 pub struct Model {
@@ -13,6 +15,7 @@ pub struct Model {
     pub created_at: DateTime<Utc>,
     pub changed_at: DateTime<Utc>,
     pub status: ProjectStatus,
+    pub notification_settings: NotificationSettings,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/cronback-services/src/metadata/migration/m20230726_115454_add_notification_settings.rs
+++ b/cronback-services/src/metadata/migration/m20230726_115454_add_notification_settings.rs
@@ -1,0 +1,37 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .add_column(
+                        ColumnDef::new(Projects::NotificationSettings).json(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .drop_column(Projects::NotificationSettings)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum Projects {
+    Table,
+    NotificationSettings,
+}

--- a/cronback-services/src/metadata/migration/mod.rs
+++ b/cronback-services/src/metadata/migration/mod.rs
@@ -1,12 +1,16 @@
 pub use sea_orm_migration::prelude::*;
 
 mod m20230712_205649_add_projects_model;
+mod m20230726_115454_add_notification_settings;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20230712_205649_add_projects_model::Migration)]
+        vec![
+            Box::new(m20230712_205649_add_projects_model::Migration),
+            Box::new(m20230726_115454_add_notification_settings::Migration),
+        ]
     }
 }

--- a/examples/notifications.json
+++ b/examples/notifications.json
@@ -1,0 +1,19 @@
+{
+    "channels": {
+        "email": {
+            "type": "email",
+            "address": "test@gmail.com",
+            "verified": false
+        }
+    },
+    "subscriptions": [
+        {
+            "channel_names": [
+                "email"
+            ],
+            "event": {
+                "type": "on_run_failure"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
[Events] Add project notification settings

ghstack-source-id: 2452ad00e890fa87497a785348ac29808eec1a40
Pull Request resolved: https://github.com/devtari-io/cronback/pull/18


This PR adds a new model for project notifications. The semantics of the model is explained in `notifications.proto`.

1. Adds a the model to the db model in metadata_svc and exposed it in the project store.
2. Expose setters/getters to notification settings in metadata svc.
3. Expose APIs to manipulate the notification settings. I opted into having a single endpoint for updating the notification setting json for convenience.

Later, we can also add this to the CLI.

Test plan:

```
~/repos/cronback/cronback ❯❯❯ cargo cli --localhost --secret-token adminkey admin projects create                                                                                                              ✘ 130
Project 'prj_026601H699SE7VY0YEFHRXXE75117B' was created successfully.
~/repos/cronback/cronback ❯❯❯ http -b --auth adminkey --auth-type bearer POST http://localhost:8888/v1/admin/projects/prj_026601H699SE7VY0YEFHRXXE75117B/notification_settings @examples/notifications.json


~/repos/cronback/cronback ❯❯❯ http -b --auth adminkey --auth-type bearer GET http://localhost:8888/v1/admin/projects/prj_026601H699SE7VY0YEFHRXXE75117B/notification_settings
{
    "channels": {
        "email": {
            "address": "test@gmail.com",
            "type": "email",
            "verified": false
        }
    },
    "subscriptions": [
        {
            "channel_names": [
                "email"
            ],
            "event": {
                "type": "on_run_failure"
            }
        }
    ]
}
```
