### PR TITLE
[Middleware] Fix authentication middleware to allow authenticated admins

### DIFF
--- a/cronback-services/src/api/auth_middleware.rs
+++ b/cronback-services/src/api/auth_middleware.rs
@@ -120,13 +120,13 @@ pub async fn ensure_authenticated<B>(
         "All endpoints should have passed by the authentication middleware",
     );
     match auth {
-        | AuthenticationStatus::Admin(Some(_))
         | AuthenticationStatus::Admin(None) => {
             Err(ApiError::BadRequest(
                 "Super privilege header(s) missing!".to_owned(),
             ))
         }
-        | AuthenticationStatus::Authenticated(_) => Ok(next.run(req).await),
+        | AuthenticationStatus::Authenticated(_)
+        | AuthenticationStatus::Admin(Some(_)) => Ok(next.run(req).await),
         | AuthenticationStatus::Unauthenticated => Err(ApiError::Unauthorized),
     }
 }


### PR DESCRIPTION
Authenticated admins should be allowed to access endpoints with `ensure_authenticated` middleware.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #22

