### PR TITLE
[Configs] Fix config env overrides

### DIFF
--- a/cronback-lib/service.rs
+++ b/cronback-lib/service.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::convert::Infallible;
 use std::error::Error;
 use std::net::SocketAddr;
@@ -57,6 +58,12 @@ pub trait CronbackService: Send + Sync + Sized + Clone + 'static {
         shutdown: Shutdown,
     ) -> ServiceContext<Self> {
         ServiceContext::new(config, shutdown)
+    }
+
+    // The list of keys in this service configs that should be parsed
+    // as vectors.
+    fn config_vec_keys() -> HashSet<String> {
+        HashSet::default()
     }
 
     /// Optional hook to install telemetry for the service.

--- a/cronback-services/src/api/mod.rs
+++ b/cronback-services/src/api/mod.rs
@@ -11,6 +11,7 @@ mod logging;
 mod migration;
 mod paginated;
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -71,6 +72,12 @@ impl CronbackService for ApiService {
             Unit::Seconds,
             "Total HTTP API processing in seconds"
         );
+    }
+
+    fn config_vec_keys() -> HashSet<String> {
+        let mut set = HashSet::new();
+        set.insert("api.admin_api_keys".to_string());
+        set
     }
 
     #[tracing::instrument(skip_all, fields(service = context.service_name()))]


### PR DESCRIPTION
[Configs] Fix config env overrides

Given that `list_separator` is called, the `config` crate expects every key to be a list unless `with_list_parse_key` is called which defines the list of keys that are supposed to be vectors. This diff lets each service define which of its keys are vector and pass it during service config registration.
